### PR TITLE
build with primitive 0.8

### DIFF
--- a/byte-order.cabal
+++ b/byte-order.cabal
@@ -26,7 +26,7 @@ library
     System.ByteOrder.Class
   build-depends:
     , base >=4.11.1.0 && <5
-    , primitive >=0.6.4 && <0.8
+    , primitive >=0.6.4 && <0.9
     , primitive-unaligned >=0.1.1 && <0.2
     , wide-word >=0.1.1 && <0.2
   hs-source-dirs: src


### PR DESCRIPTION
```
❯ cabal build --constraint="primitive == 0.8.0.0" --allow-newer=primitive-unaligned:primitive --allow-newer=wide-word:primitiveResolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - primitive-unaligned-0.1.1.2 (lib) (requires download & build)
 - wide-word-0.1.5.0 (lib) (requires download & build)
 - byte-order-0.1.3.0 (lib) (first run)
Downloading  primitive-unaligned-0.1.1.2
Downloaded   primitive-unaligned-0.1.1.2
Downloading  wide-word-0.1.5.0
Starting     primitive-unaligned-0.1.1.2 (lib)
Downloaded   wide-word-0.1.5.0
Starting     wide-word-0.1.5.0 (lib)
Building     primitive-unaligned-0.1.1.2 (lib)
Building     wide-word-0.1.5.0 (lib)
Installing   primitive-unaligned-0.1.1.2 (lib)
Completed    primitive-unaligned-0.1.1.2 (lib)
Installing   wide-word-0.1.5.0 (lib)
Completed    wide-word-0.1.5.0 (lib)
Configuring library for byte-order-0.1.3.0..
Preprocessing library for byte-order-0.1.3.0..
Building library for byte-order-0.1.3.0..
[1 of 5] Compiling System.ByteOrder.Class ( src/System/ByteOrder/Class.hs, /home/chessai/haskell/byte-order/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byte-order-0.1.3.0/build/System/ByteOrder/Class.o, /home/chessai/haskell/byte-order/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byte-order-0.1.3.0/build/System/ByteOrder/Class.dyn_o )
[2 of 5] Compiling System.ByteOrder ( src/System/ByteOrder.hs, /home/chessai/haskell/byte-order/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byte-order-0.1.3.0/build/System/ByteOrder.o, /home/chessai/haskell/byte-order/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byte-order-0.1.3.0/build/System/ByteOrder.dyn_o )
[3 of 5] Compiling Data.Primitive.Ptr.BigEndian ( src/Data/Primitive/Ptr/BigEndian.hs, /home/chessai/haskell/byte-order/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byte-order-0.1.3.0/build/Data/Primitive/Ptr/BigEndian.o, /home/chessai/haskell/byte-order/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byte-order-0.1.3.0/build/Data/Primitive/Ptr/BigEndian.dyn_o )
[4 of 5] Compiling Data.Primitive.ByteArray.LittleEndian ( src/Data/Primitive/ByteArray/LittleEndian.hs, /home/chessai/haskell/byte-order/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byte-order-0.1.3.0/build/Data/Primitive/ByteArray/LittleEndian.o, /home/chessai/haskell/byte-order/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byte-order-0.1.3.0/build/Data/Primitive/ByteArray/LittleEndian.dyn_o )
[5 of 5] Compiling Data.Primitive.ByteArray.BigEndian ( src/Data/Primitive/ByteArray/BigEndian.hs, /home/chessai/haskell/byte-order/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byte-order-0.1.3.0/build/Data/Primitive/ByteArray/BigEndian.o, /home/chessai/haskell/byte-order/dist-newstyle/build/x86_64-linux/ghc-9.4.4/byte-order-0.1.3.0/build/Data/Primitive/ByteArray/BigEndian.dyn_o )
```